### PR TITLE
fix: add permissions to release workflow for tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
   prepare:
     name: Prepare version and tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}


### PR DESCRIPTION
Fixes the release workflow permission error (HTTP 403) when trying to push tags.

The 'prepare' job in the release workflow needs 'contents: write' permission to create and push git tags.

Without this permission, the workflow fails with:
\\\
remote: Permission to nickwilsonr/meticulous-addon.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/nickwilsonr/meticulous-addon/': The requested URL returned error: 403
\\\

This fix enables the prepare job to successfully auto-tag releases on master branch pushes.