### PR TITLE
fix: remove redundant select_profile button (v0.29.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable user-facing changes to this add-on are documented here.
 
+## [0.29.1] - 2026-01-31
+
+### Fixes
+- Removed redundant `select_profile` button (the `active_profile` dropdown already provides profile selection)
+
 ## [0.29.0] - 2026-01-31
 
 ### New Features

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.29.0
+version: 0.29.1
 slug: meticulous_espresso
 name: Meticulous Espresso
 description: Integration for Meticulous Espresso machines with local API support

--- a/rootfs/usr/bin/run.py
+++ b/rootfs/usr/bin/run.py
@@ -651,13 +651,6 @@ class MeticulousAddon:
                 "icon": "mdi:cancel",
                 "command_suffix": "abort_shot",
             },
-            "select_profile": {
-                "name": "Select Profile",
-                "description": "Highlight a profile on the machine (press button to load)",
-                "icon": "mdi:checkbox-marked-circle",
-                "command_suffix": "select_profile",
-                "type": "select",
-            },
             "run_profile": {
                 "name": "Run Profile",
                 "description": "Load and preheat the currently selected profile",


### PR DESCRIPTION
Removed the redundant \select_profile\ button command. The \ctive_profile\ dropdown already provides the profile selection functionality, making the separate button unnecessary.