### PR TITLE
fix: clean up stale select_profile entity from Home Assistant (v0.29.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable user-facing changes to this add-on are documented here.
 
+## [0.29.2] - 2026-01-31
+
+### Fixes
+- Clean up stale `select_profile` entity from Home Assistant that was removed in v0.29.1
+
 ## [0.29.1] - 2026-01-31
 
 ### Fixes

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.29.1
+version: 0.29.2
 slug: meticulous_espresso
 name: Meticulous Espresso
 description: Integration for Meticulous Espresso machines with local API support

--- a/rootfs/usr/bin/run.py
+++ b/rootfs/usr/bin/run.py
@@ -742,6 +742,9 @@ class MeticulousAddon:
                 for key in self._mqtt_command_mapping().keys():
                     entity_ids.add(f"{self.slug}_{key}")
 
+                # Add deprecated entity IDs that should be cleaned up
+                entity_ids.add(f"{self.slug}_select_profile")  # Removed in v0.29.1
+
                 # Publish empty payload (retain=True) to clear each config
                 for entity_id in entity_ids:
                     config_topic = f"{self.discovery_prefix}/{component}/{entity_id}/config"


### PR DESCRIPTION
The \select_profile\ button was removed in v0.29.1, but Home Assistant had cached the old entity. This fix ensures the old entity is properly cleaned up when the addon boots.