### PR TITLE
v0.30.0: Expanded machine state detection and preheat timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable user-facing changes to this add-on are documented here.
 
+## [0.30.0] - 2026-01-31
+
+### New Features
+- **Expanded machine states** — Machine now reports detailed states (Preheating, Heating, Purging, Retracting, Closing Valve, Booting, Starting) instead of just Idle/Brewing
+- **Preheat countdown timer** — New `preheat_remaining` sensor shows preheating progress in seconds
+- **Real-time status detection** — Detects preheating, heating cycles, purging operations, and other machine phases for better visibility into what your machine is doing
+
+### Improvements
+- Better Home Assistant state entity descriptions reflecting new states
+
 ## [0.29.2] - 2026-01-31
 
 ### Fixes

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.29.2
+version: 0.30.0
 slug: meticulous_espresso
 name: Meticulous Espresso
 description: Integration for Meticulous Espresso machines with local API support

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,8 +19,8 @@ The Meticulous Home Assistant add-on provides real-time integration with Meticul
 ✅ **Health Metrics**: Diagnostic data publishing (uptime, reconnect count, error tracking)
 ✅ **Graceful Degradation**: Availability topic with online/offline states
 
-### Sensors (24 total)
-- **Machine Status**: connected, state, brewing
+### Sensors (25 total)
+- **Machine Status**: connected, state, brewing, preheat_remaining
 - **Temperature**: boiler, brew head, target, external_temp_1, external_temp_2
 - **Brewing**: pressure, flow rate, shot timer, shot weight, target weight
 - **Profile**: active profile name, author
@@ -131,8 +131,9 @@ Sensors are categorized by update frequency and data type to determine optimal p
 
 **Sensor List:**
 - `sensor.meticulous_connected`: Connection status (binary)
-- `sensor.meticulous_state`: Current state (idle, brewing, steaming, heating, preheating, error)
-- `sensor.meticulous_brewing`: Extraction active flag (binary)
+- `sensor.meticulous_state`: Current machine state (Idle, Preheating, Heating, Brewing, Purging, Retracting, Closing Valve, Home, Booting, Starting)
+- `binary_sensor.meticulous_brewing`: Extraction active flag (binary)
+- `sensor.meticulous_preheat_remaining`: Time remaining for preheating in seconds
 
 **Temperature** (5 sensors)
 - `sensor.meticulous_boiler_temperature`: Boiler temp (device_class: temperature)


### PR DESCRIPTION
# Expanded Machine State Detection

This release adds comprehensive machine state reporting and a preheat countdown timer, giving Home Assistant users better visibility into what their Meticulous machine is doing.

## What's New

### New States
Instead of just Idle/Brewing, you now get:
- **Preheating**  Shows when the heater is warming water to target temperature
- **Heating**  Machine actively heating (may continue heating during other operations)
- **Purging**  Flushing water through the group head
- **Retracting**  Plunger moving back to home position
- **Closing Valve**  Machine finalizing an operation
- **Booting**  Machine initializing on startup
- **Starting**  Operation starting

### New Sensor
- **Preheat Timer** (preheat_remaining)  Shows countdown in seconds while preheating

## Technical Details
- Leverages Socket.IO status field with detailed machine status
- Adds heater status event handler for preheat tracking
- Implements priority-based state mapping (preheating > detailed status > default)
- Capital casing for all state values (Idle, Heating, etc.) for consistency

## Breaking Changes
 State values now use capital casing: Idle, Preheating, Heating, Brewing, Purging, Retracting, Closing Valve, Home, Booting, Starting

Update any automations or scripts that reference the old lowercase state values.