### PR TITLE
v0.30.3: Improve MQTT entity cleanup with multiple topic format variations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable user-facing changes to this add-on are documented here.
 
+## [0.30.3] - 2026-02-04
+
+### Fixes
+- **Entity cleanup on upgrade** — Fixed MQTT entity cleanup to properly remove old renamed sensor entities from Home Assistant during addon updates. Now tries multiple topic format variations to ensure removal works across upgrade scenarios.
+
 ## [0.30.2] - 2026-02-04
 
 ### Improvements
@@ -10,7 +15,6 @@ All notable user-facing changes to this add-on are documented here.
 ### Fixes
 - **Preheat countdown sensor** — Now displays with whole-second precision (e.g., "45s" instead of "45.63s") and uses proper timer icon in Home Assistant
 - **Preheat countdown reset** — Countdown timer properly resets to 0 when preheating finishes, preventing stale countdown values in Home Assistant
-- **Entity cleanup on upgrade** — Old renamed sensor entities are now properly removed from Home Assistant during addon updates, preventing duplicates and stale entities
 
 ## [0.30.1] - 2026-01-31
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.30.2
+version: 0.30.3
 slug: meticulous_espresso
 name: Meticulous Espresso
 description: Integration for Meticulous Espresso machines with local API support

--- a/rootfs/usr/bin/run.py
+++ b/rootfs/usr/bin/run.py
@@ -821,6 +821,7 @@ class MeticulousAddon:
                 logger.info("Detected pre-0.28.0 version - cleaning up old brew_* MQTT entities")
                 old_brew_topics = [
                     f"{self.state_prefix}/brew/state",  # Old state
+                    f"{self.slug}/brew/state",  # Alternative prefix
                     f"{self.command_prefix}/start_brew",
                     f"{self.command_prefix}/stop_brew",
                     f"{self.command_prefix}/continue_brew",
@@ -832,14 +833,18 @@ class MeticulousAddon:
                     logger.debug(f"Cleared old entity: {topic}")
                     await asyncio.sleep(0.01)
 
-                # Also clear old discovery configs for the brew commands
+                # Also clear old discovery configs for the brew commands - try multiple formats
                 old_brew_commands = ["start_brew", "stop_brew", "continue_brew"]
                 for cmd in old_brew_commands:
-                    entity_id = f"{self.slug}_{cmd}"
-                    config_topic = f"{self.discovery_prefix}/button/{entity_id}/config"
-                    self.mqtt_client.publish(config_topic, "", qos=1, retain=True)
-                    logger.debug(f"Cleared old discovery: {config_topic}")
-                    await asyncio.sleep(0.01)
+                    possible_entity_ids = [
+                        f"{self.slug}_{cmd}",
+                        f"meticulous_espresso_{cmd}",  # Hardcoded fallback
+                    ]
+                    for entity_id in possible_entity_ids:
+                        config_topic = f"{self.discovery_prefix}/button/{entity_id}/config"
+                        self.mqtt_client.publish(config_topic, "", qos=1, retain=True)
+                        logger.debug(f"Cleared old discovery: {config_topic}")
+                        await asyncio.sleep(0.01)
 
                 logger.info("Old brew_* entities cleaned up successfully")
 
@@ -848,6 +853,8 @@ class MeticulousAddon:
                 logger.info("Detected pre-0.31.0 version - cleaning preheat_remaining MQTT entity")
                 old_preheat_topics = [
                     f"{self.state_prefix}/preheat_remaining/state",
+                    f"{self.slug}/sensor/preheat_remaining/state",  # Alternative format
+                    f"{self.slug}/preheat_remaining/state",  # Another alternative
                 ]
 
                 # Publish empty payloads to old topics (retain=True) to remove from HA
@@ -856,12 +863,16 @@ class MeticulousAddon:
                     logger.debug(f"Cleared old entity: {topic}")
                     await asyncio.sleep(0.01)
 
-                # Also clear old discovery config for preheat_remaining sensor
-                entity_id = f"{self.slug}_preheat_remaining"
-                config_topic = f"{self.discovery_prefix}/sensor/{entity_id}/config"
-                self.mqtt_client.publish(config_topic, "", qos=1, retain=True)
-                logger.debug(f"Cleared old discovery: {config_topic}")
-                await asyncio.sleep(0.01)
+                # Also clear old discovery configs - try multiple possible topic formats
+                possible_entity_ids = [
+                    f"{self.slug}_preheat_remaining",
+                    "meticulous_espresso_preheat_remaining",  # Hardcoded fallback
+                ]
+                for entity_id in possible_entity_ids:
+                    config_topic = f"{self.discovery_prefix}/sensor/{entity_id}/config"
+                    self.mqtt_client.publish(config_topic, "", qos=1, retain=True)
+                    logger.debug(f"Cleared old discovery: {config_topic}")
+                    await asyncio.sleep(0.01)
 
                 logger.info("Old preheat_remaining entity cleaned up successfully")
 


### PR DESCRIPTION
## Summary

This release improves the MQTT entity cleanup process to ensure old renamed entities are properly removed from Home Assistant during addon upgrades.

## Changes

### Fixes
- **Entity cleanup on upgrade**  Fixed MQTT entity cleanup to properly remove old renamed sensor entities (e.g., old preheat_remaining sensor, old brew_* commands) from Home Assistant during addon updates by trying multiple topic format variations. This ensures cleanup works across different upgrade scenarios and addon versions.

## Technical Details

The entity cleanup system now tries multiple possible MQTT topic name variations when clearing old entities:
- State topics with different prefix formats
- Discovery config topics with both templated and hardcoded entity IDs

This makes the cleanup more robust and prevents orphaned Home Assistant entities from being left behind during upgrades.