### PR TITLE
v0.30.4: Fix cleanup of old entities during addon upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 All notable user-facing changes to this add-on are documented here.
 
-## [0.30.3] - 2026-02-04
+## [0.30.4] - 2026-02-04
 
 ### Fixes
-- **Entity cleanup on upgrade** — Fixed MQTT entity cleanup to properly remove old renamed sensor entities from Home Assistant during addon updates. Now tries multiple topic format variations to ensure removal works across upgrade scenarios.
+- **Entity cleanup on upgrade** — Old sensors and entities from previous versions are now properly removed from Home Assistant during addon updates
 
 ## [0.30.2] - 2026-02-04
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.30.3
+version: 0.30.4
 slug: meticulous_espresso
 name: Meticulous Espresso
 description: Integration for Meticulous Espresso machines with local API support

--- a/rootfs/usr/bin/run.py
+++ b/rootfs/usr/bin/run.py
@@ -829,9 +829,9 @@ class MeticulousAddon:
 
                 # Publish empty payloads to old topics (retain=True) to remove from HA
                 for topic in old_brew_topics:
-                    self.mqtt_client.publish(topic, "", qos=1, retain=True)
-                    logger.debug(f"Cleared old entity: {topic}")
-                    await asyncio.sleep(0.01)
+                    result = self.mqtt_client.publish(topic, "", qos=1, retain=True)
+                    logger.info(f"Cleared state/command topic: {topic} (rc={result.rc})")
+                    await asyncio.sleep(0.05)
 
                 # Also clear old discovery configs for the brew commands - try multiple formats
                 old_brew_commands = ["start_brew", "stop_brew", "continue_brew"]
@@ -842,9 +842,15 @@ class MeticulousAddon:
                     ]
                     for entity_id in possible_entity_ids:
                         config_topic = f"{self.discovery_prefix}/button/{entity_id}/config"
-                        self.mqtt_client.publish(config_topic, "", qos=1, retain=True)
-                        logger.debug(f"Cleared old discovery: {config_topic}")
-                        await asyncio.sleep(0.01)
+                        result = self.mqtt_client.publish(config_topic, "", qos=1, retain=True)
+                        logger.info(f"Cleared discovery config: {config_topic} (rc={result.rc})")
+                        await asyncio.sleep(0.05)
+
+                # Also ensure availability topic is properly cleared
+                availability_topic = f"{self.slug}/availability"
+                result = self.mqtt_client.publish(availability_topic, "", qos=1, retain=True)
+                logger.info(f"Cleared availability topic: {availability_topic} (rc={result.rc})")
+                await asyncio.sleep(0.05)
 
                 logger.info("Old brew_* entities cleaned up successfully")
 
@@ -859,9 +865,9 @@ class MeticulousAddon:
 
                 # Publish empty payloads to old topics (retain=True) to remove from HA
                 for topic in old_preheat_topics:
-                    self.mqtt_client.publish(topic, "", qos=1, retain=True)
-                    logger.debug(f"Cleared old entity: {topic}")
-                    await asyncio.sleep(0.01)
+                    result = self.mqtt_client.publish(topic, "", qos=1, retain=True)
+                    logger.info(f"Cleared state topic: {topic} (rc={result.rc})")
+                    await asyncio.sleep(0.05)
 
                 # Also clear old discovery configs - try multiple possible topic formats
                 possible_entity_ids = [
@@ -870,9 +876,15 @@ class MeticulousAddon:
                 ]
                 for entity_id in possible_entity_ids:
                     config_topic = f"{self.discovery_prefix}/sensor/{entity_id}/config"
-                    self.mqtt_client.publish(config_topic, "", qos=1, retain=True)
-                    logger.debug(f"Cleared old discovery: {config_topic}")
-                    await asyncio.sleep(0.01)
+                    result = self.mqtt_client.publish(config_topic, "", qos=1, retain=True)
+                    logger.info(f"Cleared discovery config: {config_topic} (rc={result.rc})")
+                    await asyncio.sleep(0.05)
+
+                # Also ensure availability topic is properly cleared
+                availability_topic = f"{self.slug}/availability"
+                result = self.mqtt_client.publish(availability_topic, "", qos=1, retain=True)
+                logger.info(f"Cleared availability topic: {availability_topic} (rc={result.rc})")
+                await asyncio.sleep(0.05)
 
                 logger.info("Old preheat_remaining entity cleaned up successfully")
 


### PR DESCRIPTION
## Summary

This release fixes the cleanup of old entities from previous addon versions during upgrades.

## Changes

### Fixes
- **Entity cleanup on upgrade**  Old sensors and entities from previous versions are now properly removed from Home Assistant during addon updates