### PR TITLE
v0.30.6: Improved MQTT entity cleanup with reliable discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable user-facing changes to this add-on are documented here.
 
-## [0.30.5] - 2026-02-04
+## [0.30.6] - 2026-02-04
 
 ### Fixes
 - **Entity cleanup on upgrade** — Old sensors and entities from previous versions are now properly removed from Home Assistant during addon updates

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.30.5
+version: 0.30.6
 slug: meticulous_espresso
 name: Meticulous Espresso
 description: Integration for Meticulous Espresso machines with local API support

--- a/rootfs/usr/bin/run.py
+++ b/rootfs/usr/bin/run.py
@@ -831,8 +831,8 @@ class MeticulousAddon:
             logger.info(f"Discovering entities with pattern: {discovery_pattern}")
             self.mqtt_client.subscribe(discovery_pattern, qos=1)
 
-            # Wait for broker to send all retained messages
-            await asyncio.sleep(0.5)
+            # Wait for broker to send all retained messages (need sufficient time)
+            await asyncio.sleep(2.0)
 
             # Unsubscribe from discovery
             self.mqtt_client.unsubscribe(discovery_pattern)


### PR DESCRIPTION
## Summary

This release improves the entity cleanup mechanism during add-on upgrades using MQTT discovery wildcards. Includes a critical fix to the discovery wait time to ensure all entities are properly detected.

## Changes

### Fixes
- **MQTT discovery wait time**  Increased from 0.5s to 2.0s to allow the broker sufficient time to deliver all retained messages matching the discovery wildcard pattern

### Improvements
- **MQTT entity cleanup redesign**  Now uses MQTT wildcard subscriptions to discover all existing entities and clear them dynamically, eliminating fragile version-dependent tracking
- Works seamlessly with any entity name or type changes in future versions
- Backward-compatible with all previous versions

### How it works
- Subscribes to \homeassistant/+/meticulous_espresso*/\#\ to discover all device entities
- Clears all discovered topics (discovery configs and state topics)
- Home Assistant automatically removes the device when all entities are cleared
- Device and entities recreate fresh from new discovery topics on next startup

### Benefits
- No version migration logic needed
- Works for any entity name/type changes
- Only removes what actually exists on the broker
- Future-proof design