### PR TITLE
feat: sync and publish profile images as HA image entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ htmlcov/
 
 # Logs
 *.log
+
+# Git worktrees
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable user-facing changes to this add-on are documented here.
 
+## [0.31.8] - 2026-03-03
+
+### New Features
+- **Profile image entity** (manonstreet) — Your active profile's image now appears as a native Home Assistant image entity. Updates automatically when you change profiles via the mobile app or Home Assistant — and is ready to update from the machine itself when a future firmware update lands
+- **Active profile filename sensor** (manonstreet) — New sensor exposing the current profile's image filename, useful for building dynamic dashboard templates
+
 ## [0.31.7] - 2026-02-16
 
 ### Improvements
@@ -74,7 +80,7 @@ All notable user-facing changes to this add-on are documented here.
 ## [0.29.1] - 2026-01-31
 
 ### Fixes
-- Removed redundant `select_profile` button (the `active_profile` dropdown already provides profile selection)
+- Removed redundant `select_profile` button (the `active_profile` dropdown already handles profile selection)
 
 ## [0.29.0] - 2026-01-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ All notable user-facing changes to this add-on are documented here.
 ## [0.29.1] - 2026-01-31
 
 ### Fixes
-- Removed redundant `select_profile` button (the `active_profile` dropdown already handles profile selection)
+- Removed redundant `select_profile` button (the `active_profile` dropdown already provides profile selection)
 
 ## [0.29.0] - 2026-01-31
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Integrate your Meticulous Espresso machine with Home Assistant for real-time mon
 
 - **Real-time brewing data**: Pressure, flow rate, weight, shot timer
 - **Temperature monitoring**: Boiler and brew head temperatures
-- **24 automatic sensors**: Machine status, profiles, statistics, device info, connectivity
+- **25 automatic sensors**: Machine status, profiles, statistics, device info, connectivity
 - **8 control commands**: Start/stop/continue brew, preheat, tare scale, load profiles, adjust brightness, toggle sounds
+- **Profile image entity**: Active profile image available as a native HA image entity for use in dashboards
 - **MQTT auto-discovery**: Entities appear automatically in Home Assistant
 - **Graceful reconnection**: Automatic recovery from network issues
 
@@ -91,7 +92,7 @@ MQTT credentials if required by your broker. These are automatically fetched fro
 
 Once connected, the add-on automatically creates entities in Home Assistant:
 
-### Sensors (24 total)
+### Sensors (25 total)
 
 **Connectivity & Status** (3 sensors)
 - `binary_sensor.meticulous_connected` — Machine connection status
@@ -112,9 +113,11 @@ Once connected, the add-on automatically creates entities in Home Assistant:
 - `sensor.meticulous_shot_weight` — Current weight (grams)
 - `sensor.meticulous_target_weight` — Profile target weight
 
-**Profile** (2 sensors)
+**Profile** (4 sensors)
 - `sensor.meticulous_active_profile` — Currently loaded profile name
 - `sensor.meticulous_profile_author` — Profile creator
+- `image.meticulous_active_profile_image` — Active profile image
+- `sensor.meticulous_active_profile_filename` — Active profile image filename (useful for cache-busting in dashboard templates)
 
 **Statistics** (4 sensors)
 - `sensor.meticulous_total_shots` — Lifetime shot count

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,4 @@
----
-version: 0.31.7
+version: 0.31.8
 slug: meticulous_espresso
 name: Meticulous Espresso
 description: Integration for Meticulous Espresso machines with local API support

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -204,6 +204,20 @@ Home Assistant (MQTT discovery)
 Automations & Dashboard
 ```
 
+### Profile Image Caching
+
+When `fetch_available_profiles()` runs, the add-on:
+
+1. Reads `display.image` from each `PartialProfile` returned by `/api/v1/profile/list`
+2. Extracts the filename (e.g. `abc123.jpg`) via `os.path.basename()`
+3. Fetches any uncached images from `http://{machine_ip}:8080/api/v1/profile/image/{filename}` using `self.api.session`
+4. Writes them to `/config/www/meticulous/profiles/` — served by HA at `/local/meticulous/profiles/`
+5. Removes stale files (profiles that no longer exist)
+
+The raw binary image bytes for the active profile are published to `meticulous_espresso/sensor/active_profile_image/state` via MQTT `image_topic`, which backs an `image` entity in Home Assistant created via MQTT discovery. The cached files in `/config/www/meticulous/profiles/` are the source for these publishes; HA receives and displays the bytes directly without any HTTP proxying.
+
+The active profile's image filename (e.g. `abc123.jpg`) is published separately to `meticulous_espresso/sensor/active_profile_filename/state` as a plain string sensor. This is useful for cache-busting in dashboard templates via `states('sensor.meticulous_espresso_active_profile_filename')`.
+
 ### Socket.IO Events (Priority)
 
 1. **onStatus** (CRITICAL): state, extracting, time, sensors (p, f, w, t)

--- a/docs/mqtt-topics.md
+++ b/docs/mqtt-topics.md
@@ -36,6 +36,8 @@ homeassistant/sensor/meticulous_espresso_total_shots/config
 homeassistant/sensor/meticulous_espresso_last_shot_name/config
 homeassistant/sensor/meticulous_espresso_last_shot_rating/config
 homeassistant/sensor/meticulous_espresso_last_shot_time/config
+homeassistant/image/meticulous_espresso_active_profile_image/config
+homeassistant/sensor/meticulous_espresso_active_profile_filename/config
 ```
 
 ## State Topics
@@ -67,6 +69,9 @@ meticulous_espresso/sensor/total_shots/state            → 1234
 meticulous_espresso/sensor/last_shot_name/state         → "Espresso"
 meticulous_espresso/sensor/last_shot_rating/state       → "like"
 meticulous_espresso/sensor/last_shot_time/state         → "2024-01-15T10:30:00"
+meticulous_espresso/sensor/active_profile_image/state    → <binary PNG image data>
+meticulous_espresso/sensor/active_profile_filename/state → "abc123.jpg"
+meticulous_espresso/profiles                             → [{"profile_id": "...", "name": "...", "image_filename": "..."}]
 ```
 
 ## Command Topics

--- a/rootfs/usr/bin/mqtt_commands.py
+++ b/rootfs/usr/bin/mqtt_commands.py
@@ -228,6 +228,7 @@ def handle_command_select_profile(addon: "MeticulousAddon", profile_name: str):
             state_topic = f"{addon.state_prefix}/active_profile/state"
             addon.mqtt_client.publish(state_topic, profile_name, qos=1, retain=True)
             logger.debug(f"Published active_profile state: {profile_name}")
+            addon._resolve_and_publish_active_image()
     except Exception as e:
         logger.error(f"select_profile error: {e}", exc_info=True)
 


### PR DESCRIPTION
## Summary

- Caches profile images from the machine API to `/config/www/meticulous/profiles/` on startup and whenever the profile list is refreshed (stale files are pruned automatically)
- Publishes a profiles manifest to `meticulous_espresso/profiles` — a JSON array of `{profile_id, name, image_filename}` for external consumers
- Creates a native HA `image` entity via MQTT discovery that displays the active profile's image, updated on every profile change
- Exposes the active profile's image filename as a dedicated `sensor` entity — useful for cache-busting in dashboard templates via `states('sensor.meticulous_espresso_active_profile_filename')`

## New MQTT Topics

```
meticulous_espresso/sensor/active_profile_image/state     → <binary image bytes>
meticulous_espresso/sensor/active_profile_filename/state  → "abc123.jpg"
meticulous_espresso/profiles                              → [{"profile_id": "...", "name": "...", "image_filename": "..."}]
```

## New HA Entities

```
homeassistant/image/meticulous_espresso_active_profile_image/config
homeassistant/sensor/meticulous_espresso_active_profile_filename/config
```

## Implementation Notes

- Image selection is driven by `profileHover` Socket.IO events (iOS app, HA select entity, profile load/create via backend)
- A pending hover is stored when the event arrives before the profile list is populated, and resolved on the next fetch cycle
- On startup, `GET /profile/selected` is used to seed the correct profile rather than falling back to last-brewed
- Duplicate image publishes are suppressed to avoid triggering unnecessary visual refreshes in HA