### PR TITLE
Fix last shot sensors not updating after extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable user-facing changes to this add-on are documented here.
 
+## [0.31.9] - 2026-03-10
+
+### Fixes
+- **Stale connection recovery** — The add-on now automatically retries when the machine drops an idle HTTP connection (common after overnight idle), instead of failing silently until the next polling cycle
+- **Last shot sensors** — Shot name, rating, and timestamp now update reliably in all cases
+
 ## [0.31.8] - 2026-03-03
 
 ### New Features

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-version: 0.31.8
+version: 0.31.9
 slug: meticulous_espresso
 name: Meticulous Espresso
 description: Integration for Meticulous Espresso machines with local API support

--- a/rootfs/usr/bin/run.py
+++ b/rootfs/usr/bin/run.py
@@ -14,6 +14,8 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 
 import aiohttp
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 # Import Meticulous API
 try:
@@ -322,6 +324,12 @@ class MeticulousAddon:
 
             # Initialize API (REST only, Socket.IO will connect separately)
             self.api = Api(base_url=base_url, options=options)  # type: ignore[assignment]
+
+            # Auto-retry once on stale pooled connections (overnight idle)
+            retry = Retry(total=1, connect=1, read=1, allowed_methods=None)
+            adapter = HTTPAdapter(max_retries=retry)
+            self.api.session.mount("http://", adapter)
+            self.api.session.mount("https://", adapter)
 
             # Test connection by fetching device info
             try:
@@ -1262,7 +1270,35 @@ class MeticulousAddon:
                     else:
                         logger.debug(f"get_last_shot returned None or APIError: {last_shot}")
                 except Exception as e:
-                    logger.warning(f"Could not fetch initial last shot: {e}", exc_info=True)
+                    # Fallback: pyMeticulous validation can fail if firmware
+                    # omits fields (e.g. sensors on final data point).
+                    logger.warning(
+                        f"get_last_shot failed ({type(e).__name__}), "
+                        "trying raw API fallback"
+                    )
+                    try:
+                        import requests as req
+                        base = f"http://{self.machine_ip}:8080"
+                        raw = req.get(f"{base}/api/v1/history/last").json()
+                        if raw.get("name"):
+                            initial_data["last_shot_name"] = raw["name"]
+                        initial_data["last_shot_rating"] = (
+                            raw.get("rating") or "none"
+                        )
+                        ts = raw.get("time")
+                        if ts is not None:
+                            initial_data["last_shot_time"] = (
+                                datetime.fromtimestamp(ts)
+                                .astimezone().isoformat()
+                            )
+                        logger.info(
+                            "Got initial last shot via raw API fallback"
+                        )
+                    except Exception as fallback_err:
+                        logger.warning(
+                            f"Raw API fallback also failed: {fallback_err}",
+                            exc_info=True
+                        )
 
             except Exception as e:
                 logger.debug(f"Could not fetch initial statistics: {e}")
@@ -2356,9 +2392,37 @@ class MeticulousAddon:
                 await self.publish_to_homeassistant(last_shot_data)
                 logger.debug("Updated last shot data")
             except Exception as e:
+                # Fallback: pyMeticulous validation can fail if firmware
+                # omits fields (e.g. sensors on final data point). Fetch
+                # raw JSON for just the metadata we need.
                 logger.warning(
-                    f"Could not retrieve last shot: " f"{type(e).__name__}: {e}", exc_info=True
+                    f"get_last_shot failed ({type(e).__name__}), "
+                    "trying raw API fallback"
                 )
+                try:
+                    import requests as req
+                    base = f"http://{self.machine_ip}:8080"
+                    raw = await asyncio.get_running_loop().run_in_executor(
+                        None, lambda: req.get(
+                            f"{base}/api/v1/history/last"
+                        ).json()
+                    )
+                    last_shot_data["last_shot_name"] = raw.get("name")
+                    last_shot_data["last_shot_rating"] = (
+                        raw.get("rating") or "none"
+                    )
+                    ts = raw.get("time")
+                    if ts is not None:
+                        last_shot_data["last_shot_time"] = (
+                            datetime.fromtimestamp(ts).astimezone().isoformat()
+                        )
+                    await self.publish_to_homeassistant(last_shot_data)
+                    logger.info("Updated last shot data via raw API fallback")
+                except Exception as fallback_err:
+                    logger.warning(
+                        f"Raw API fallback also failed: {fallback_err}",
+                        exc_info=True
+                    )
 
         except Exception as e:
             logger.error(f"Error updating statistics: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- `sensor.meticulous_espresso_last_shot_name` and `last_shot_time` stop updating because `get_last_shot()` throws a `ValidationError` — the machine firmware omits the `sensors` field on the final retraction data point
- Adds a raw HTTP API fallback in both startup and post-shot paths to parse shot metadata (name, rating, time) when pyMeticulous model validation fails

## Root cause
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for HistoryEntry
data.782.sensors
  Field required [type=missing, ...]
```
The last data point in every shot consistently omits `sensors`. Upstream pyMeticulous fix: MeticulousHome/pyMeticulous#21

## Test plan
- [ ] Pull a shot, verify `last_shot_name` and `last_shot_time` update in HA
- [ ] Restart add-on, verify initial state populates last shot info

🤖 Generated with [Claude Code](https://claude.com/claude-code)